### PR TITLE
Fetch all projects and teams via cursor pagination

### DIFF
--- a/src/app/api/linear/projects/route.ts
+++ b/src/app/api/linear/projects/route.ts
@@ -13,65 +13,85 @@ export async function POST(request: NextRequest) {
 
     console.log('Projects API - Token length:', apiToken.length, 'First 20 chars:', apiToken.substring(0, 20));
 
-    // Get projects from Linear using direct GraphQL request
-    const query = `
-      query Projects {
-        projects {
-          nodes {
-            id
-            name
-            description
-            createdAt
+    // Fetch all projects via cursor pagination (Linear API max is 250 per page)
+    type ProjectNode = {
+      id: string
+      name: string
+      description?: string
+      createdAt: string
+    }
+
+    const allProjects: ProjectNode[] = [];
+    let endCursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const query = `
+        query Projects($after: String) {
+          projects(first: 250, after: $after) {
+            nodes {
+              id
+              name
+              description
+              createdAt
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
         }
-      }
-    `;
+      `;
 
-    const response = await fetch('https://api.linear.app/graphql', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': apiToken.trim()
-      },
-      body: JSON.stringify({ query })
-    });
+      const response = await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': apiToken.trim()
+        },
+        body: JSON.stringify({ query, variables: { after: endCursor } })
+      });
 
-    if (!response.ok) {
-      let errorDetails = '';
-      try {
-        const errorBody = await response.text();
-        errorDetails = ` - ${errorBody}`;
-      } catch {
-        // Ignore text parsing errors
-      }
-      throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
-    }
-
-    const result = await response.json() as {
-      data?: {
-        projects: {
-          nodes: Array<{
-            id: string
-            name: string
-            description?: string
-            createdAt: string
-          }>
+      if (!response.ok) {
+        let errorDetails = '';
+        try {
+          const errorBody = await response.text();
+          errorDetails = ` - ${errorBody}`;
+        } catch {
+          // Ignore text parsing errors
         }
+        throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
       }
-      errors?: Array<{ message: string }>
-    };
 
-    if (result.errors) {
-      throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
-    }
+      const result = await response.json() as {
+        data?: {
+          projects: {
+            nodes: ProjectNode[]
+            pageInfo: {
+              hasNextPage: boolean
+              endCursor: string | null
+            }
+          }
+        }
+        errors?: Array<{ message: string }>
+      };
 
-    if (!result.data) {
-      throw new Error('No data returned from Linear API');
+      if (result.errors) {
+        throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
+      }
+
+      if (!result.data) {
+        throw new Error('No data returned from Linear API');
+      }
+
+      allProjects.push(...result.data.projects.nodes);
+      hasNextPage = result.data.projects.pageInfo.hasNextPage;
+      endCursor = result.data.projects.pageInfo.endCursor;
     }
 
     return NextResponse.json({
       success: true,
-      projects: result.data.projects.nodes.map(project => ({
+      projects: allProjects.map(project => ({
         id: project.id,
         name: project.name,
         description: project.description

--- a/src/app/api/linear/teams/route.ts
+++ b/src/app/api/linear/teams/route.ts
@@ -20,65 +20,85 @@ export async function POST(request: NextRequest) {
 
     console.log('Teams API - Token length:', apiToken.length, 'First 20 chars:', apiToken.substring(0, 20));
 
-    // Get teams from Linear using GraphQL
-    const query = `
-      query Teams {
-        teams {
-          nodes {
-            id
-            name
-            key
-            description
+    // Fetch all teams via cursor pagination (Linear API max is 250 per page)
+    type TeamNode = {
+      id: string
+      name: string
+      key: string
+      description?: string
+    }
+
+    const allTeams: TeamNode[] = [];
+    let endCursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const query = `
+        query Teams($after: String) {
+          teams(first: 250, after: $after) {
+            nodes {
+              id
+              name
+              key
+              description
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
         }
-      }
-    `;
+      `;
 
-    const response = await fetch('https://api.linear.app/graphql', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': apiToken.trim()
-      },
-      body: JSON.stringify({ query })
-    });
+      const response = await fetch('https://api.linear.app/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': apiToken.trim()
+        },
+        body: JSON.stringify({ query, variables: { after: endCursor } })
+      });
 
-    if (!response.ok) {
-      let errorDetails = '';
-      try {
-        const errorBody = await response.text();
-        errorDetails = ` - ${errorBody}`;
-      } catch {
-        // Ignore text parsing errors
-      }
-      throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
-    }
-
-    const result = await response.json() as {
-      data?: {
-        teams: {
-          nodes: Array<{
-            id: string
-            name: string
-            key: string
-            description?: string
-          }>
+      if (!response.ok) {
+        let errorDetails = '';
+        try {
+          const errorBody = await response.text();
+          errorDetails = ` - ${errorBody}`;
+        } catch {
+          // Ignore text parsing errors
         }
+        throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
       }
-      errors?: Array<{ message: string }>
-    };
 
-    if (result.errors) {
-      throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
-    }
+      const result = await response.json() as {
+        data?: {
+          teams: {
+            nodes: TeamNode[]
+            pageInfo: {
+              hasNextPage: boolean
+              endCursor: string | null
+            }
+          }
+        }
+        errors?: Array<{ message: string }>
+      };
 
-    if (!result.data) {
-      throw new Error('No data returned from Linear API');
+      if (result.errors) {
+        throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
+      }
+
+      if (!result.data) {
+        throw new Error('No data returned from Linear API');
+      }
+
+      allTeams.push(...result.data.teams.nodes);
+      hasNextPage = result.data.teams.pageInfo.hasNextPage;
+      endCursor = result.data.teams.pageInfo.endCursor;
     }
 
     return NextResponse.json({
       success: true,
-      teams: result.data.teams.nodes.map(team => ({
+      teams: allTeams.map(team => ({
         id: team.id,
         name: team.name,
         key: team.key,


### PR DESCRIPTION
Linear's projects and teams queries without first parameter default to 50 results. For workspaces with more projects/teams, the rest are missing from the Source type dropdown in view create/edit forms.

Fix: Use cursor-based pagination (first: 250 + pageInfo.hasNextPage/endCursor) to fetch all projects and teams across multiple API calls.