### PR TITLE
refactor: share Linear pagination helper; paginate issues and project-updates

### DIFF
--- a/src/app/api/linear/issues/route.ts
+++ b/src/app/api/linear/issues/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { paginateLinearConnection, type LinearConnection } from "@/lib/linear";
 
 export type LinearIssue = {
   id: string;
@@ -40,6 +41,21 @@ export type RequestBody = {
   statuses?: string[];
 };
 
+type IssueNode = {
+  id: string;
+  identifier: string;
+  title: string;
+  description?: string;
+  priority: number;
+  priorityLabel: string;
+  url: string;
+  state: { id: string; name: string; color: string; type: string };
+  assignee?: { id: string; name: string };
+  labels: { nodes: Array<{ id: string; name: string; color: string }> };
+  createdAt: string;
+  updatedAt: string;
+};
+
 export async function POST(request: NextRequest) {
   try {
     const { apiToken, projectId, teamId, statuses } =
@@ -59,7 +75,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Build the filter conditions
     let filterCondition = "";
     if (projectId) {
       filterCondition = `project: { id: { eq: "${projectId}" } }`;
@@ -67,7 +82,6 @@ export async function POST(request: NextRequest) {
       filterCondition = `team: { id: { eq: "${teamId}" } }`;
     }
 
-    // Add status filter if provided
     if (statuses && statuses.length > 0) {
       const statusFilter = `state: { name: { in: [${statuses.map((s) => `"${s}"`).join(", ")}] } }`;
       filterCondition = filterCondition
@@ -75,13 +89,13 @@ export async function POST(request: NextRequest) {
         : statusFilter;
     }
 
-    // Get issues from Linear using GraphQL - simplified to reduce complexity
     const query = `
-      query Issues {
+      query Issues($after: String) {
         issues(
           filter: { ${filterCondition} }
           orderBy: updatedAt
-          first: 50
+          first: 250
+          after: $after
         ) {
           nodes {
             id
@@ -111,73 +125,26 @@ export async function POST(request: NextRequest) {
             createdAt
             updatedAt
           }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
         }
       }
     `;
 
-    const response = await fetch("https://api.linear.app/graphql", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `${apiToken.replace(/[^\x00-\xFF]/g, "")}`,
-      },
-      body: JSON.stringify({ query }),
+    const result = await paginateLinearConnection<IssueNode>({
+      apiToken,
+      query,
+      extract: (data) =>
+        (data as { issues: LinearConnection<IssueNode> }).issues,
     });
 
-    if (!response.ok) {
-      throw new Error(
-        `Linear API error: ${response.status} ${response.statusText}`,
-      );
+    if (!result.success) {
+      throw new Error(result.error);
     }
 
-    const result = (await response.json()) as {
-      data?: {
-        issues: {
-          nodes: Array<{
-            id: string;
-            identifier: string;
-            title: string;
-            description?: string;
-            priority: number;
-            priorityLabel: string;
-            url: string;
-            state: {
-              id: string;
-              name: string;
-              color: string;
-              type: string;
-            };
-            assignee?: {
-              id: string;
-              name: string;
-            };
-            labels: {
-              nodes: Array<{
-                id: string;
-                name: string;
-                color: string;
-              }>;
-            };
-            createdAt: string;
-            updatedAt: string;
-          }>;
-        };
-      };
-      errors?: Array<{ message: string }>;
-    };
-
-    if (result.errors) {
-      throw new Error(
-        `GraphQL errors: ${result.errors.map((e) => e.message).join(", ")}`,
-      );
-    }
-
-    if (!result.data) {
-      throw new Error("No data returned from Linear API");
-    }
-
-    // Transform the data to match our LinearIssue type
-    const issues: LinearIssue[] = result.data.issues.nodes.map((issue) => ({
+    const issues: LinearIssue[] = result.nodes.map((issue) => ({
       id: issue.id,
       identifier: issue.identifier,
       title: issue.title,

--- a/src/app/api/linear/project-updates/route.ts
+++ b/src/app/api/linear/project-updates/route.ts
@@ -1,4 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { paginateLinearConnection, type LinearConnection } from '@/lib/linear';
+
+type ProjectUpdate = {
+  id: string
+  body: string
+  createdAt: string
+  editedAt?: string
+  health: string
+  user: {
+    id: string
+    name: string
+    displayName: string
+    avatarUrl?: string
+    email: string
+  }
+  diff?: unknown
+  diffMarkdown?: string
+  isDiffHidden: boolean
+  project: {
+    id: string
+    name: string
+    progress: number
+    state: string
+  }
+}
+
+type ProjectWithUpdates = {
+  id: string
+  name: string
+  projectUpdates: LinearConnection<ProjectUpdate>
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,13 +42,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get project updates from Linear using direct GraphQL request
     const query = `
-      query ProjectUpdates($projectId: String!) {
+      query ProjectUpdates($projectId: String!, $after: String) {
         project(id: $projectId) {
           id
           name
-          projectUpdates {
+          projectUpdates(first: 250, after: $after) {
             nodes {
               id
               body
@@ -41,81 +71,39 @@ export async function POST(request: NextRequest) {
                 state
               }
             }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
         }
       }
     `;
 
-    const response = await fetch('https://api.linear.app/graphql', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': apiToken.trim()
+    // Capture project metadata from the first page so we can return it alongside the updates.
+    let projectMeta: { id: string; name: string } | null = null;
+
+    const result = await paginateLinearConnection<ProjectUpdate>({
+      apiToken,
+      query,
+      variables: { projectId },
+      extract: (data) => {
+        const project = (data as { project: ProjectWithUpdates }).project;
+        if (!projectMeta) {
+          projectMeta = { id: project.id, name: project.name };
+        }
+        return project.projectUpdates;
       },
-      body: JSON.stringify({
-        query,
-        variables: { projectId }
-      })
     });
 
-    if (!response.ok) {
-      let errorDetails = '';
-      try {
-        const errorBody = await response.text();
-        errorDetails = ` - ${errorBody}`;
-      } catch {
-        // Ignore text parsing errors
-      }
-      throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
-    }
-
-    const result = await response.json() as {
-      data?: {
-        project: {
-          id: string
-          name: string
-          projectUpdates: {
-            nodes: Array<{
-              id: string
-              body: string
-              createdAt: string
-              editedAt?: string
-              health: string
-              user: {
-                id: string
-                name: string
-                displayName: string
-                avatarUrl?: string
-                email: string
-              }
-              diff?: unknown
-              diffMarkdown?: string
-              isDiffHidden: boolean
-              project: {
-                id: string
-                name: string
-                progress: number
-                state: string
-              }
-            }>
-          }
-        }
-      }
-      errors?: Array<{ message: string }>
-    };
-
-    if (result.errors) {
-      throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
-    }
-
-    if (!result.data) {
-      throw new Error('No data returned from Linear API');
+    if (!result.success) {
+      throw new Error(result.error);
     }
 
     return NextResponse.json({
       success: true,
-      project: result.data.project,
-      updates: result.data.project.projectUpdates.nodes
+      project: projectMeta,
+      updates: result.nodes
     });
 
   } catch (error) {

--- a/src/app/api/linear/projects/route.ts
+++ b/src/app/api/linear/projects/route.ts
@@ -1,4 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { paginateLinearConnection, type LinearConnection } from '@/lib/linear';
+
+type ProjectNode = {
+  id: string
+  name: string
+  description?: string
+  createdAt: string
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,87 +19,37 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log('Projects API - Token length:', apiToken.length, 'First 20 chars:', apiToken.substring(0, 20));
-
-    // Fetch all projects via cursor pagination (Linear API max is 250 per page)
-    type ProjectNode = {
-      id: string
-      name: string
-      description?: string
-      createdAt: string
-    }
-
-    const allProjects: ProjectNode[] = [];
-    let endCursor: string | null = null;
-    let hasNextPage = true;
-
-    while (hasNextPage) {
-      const query = `
-        query Projects($after: String) {
-          projects(first: 250, after: $after) {
-            nodes {
-              id
-              name
-              description
-              createdAt
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+    const query = `
+      query Projects($after: String) {
+        projects(first: 250, after: $after) {
+          nodes {
+            id
+            name
+            description
+            createdAt
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
           }
         }
-      `;
-
-      const response = await fetch('https://api.linear.app/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': apiToken.trim()
-        },
-        body: JSON.stringify({ query, variables: { after: endCursor } })
-      });
-
-      if (!response.ok) {
-        let errorDetails = '';
-        try {
-          const errorBody = await response.text();
-          errorDetails = ` - ${errorBody}`;
-        } catch {
-          // Ignore text parsing errors
-        }
-        throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
       }
+    `;
 
-      const result = await response.json() as {
-        data?: {
-          projects: {
-            nodes: ProjectNode[]
-            pageInfo: {
-              hasNextPage: boolean
-              endCursor: string | null
-            }
-          }
-        }
-        errors?: Array<{ message: string }>
-      };
+    const result = await paginateLinearConnection<ProjectNode>({
+      apiToken,
+      query,
+      extract: (data) =>
+        (data as { projects: LinearConnection<ProjectNode> }).projects,
+    });
 
-      if (result.errors) {
-        throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
-      }
-
-      if (!result.data) {
-        throw new Error('No data returned from Linear API');
-      }
-
-      allProjects.push(...result.data.projects.nodes);
-      hasNextPage = result.data.projects.pageInfo.hasNextPage;
-      endCursor = result.data.projects.pageInfo.endCursor;
+    if (!result.success) {
+      throw new Error(result.error);
     }
 
     return NextResponse.json({
       success: true,
-      projects: allProjects.map(project => ({
+      projects: result.nodes.map(project => ({
         id: project.id,
         name: project.name,
         description: project.description

--- a/src/app/api/linear/teams/route.ts
+++ b/src/app/api/linear/teams/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { paginateLinearConnection, type LinearConnection } from '@/lib/linear';
 
 export type Team = {
   id: string
@@ -6,6 +7,8 @@ export type Team = {
   key: string
   description?: string
 }
+
+type TeamNode = Team;
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,87 +21,37 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log('Teams API - Token length:', apiToken.length, 'First 20 chars:', apiToken.substring(0, 20));
-
-    // Fetch all teams via cursor pagination (Linear API max is 250 per page)
-    type TeamNode = {
-      id: string
-      name: string
-      key: string
-      description?: string
-    }
-
-    const allTeams: TeamNode[] = [];
-    let endCursor: string | null = null;
-    let hasNextPage = true;
-
-    while (hasNextPage) {
-      const query = `
-        query Teams($after: String) {
-          teams(first: 250, after: $after) {
-            nodes {
-              id
-              name
-              key
-              description
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
+    const query = `
+      query Teams($after: String) {
+        teams(first: 250, after: $after) {
+          nodes {
+            id
+            name
+            key
+            description
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
           }
         }
-      `;
-
-      const response = await fetch('https://api.linear.app/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': apiToken.trim()
-        },
-        body: JSON.stringify({ query, variables: { after: endCursor } })
-      });
-
-      if (!response.ok) {
-        let errorDetails = '';
-        try {
-          const errorBody = await response.text();
-          errorDetails = ` - ${errorBody}`;
-        } catch {
-          // Ignore text parsing errors
-        }
-        throw new Error(`Linear API error: ${response.status} ${response.statusText}${errorDetails}`);
       }
+    `;
 
-      const result = await response.json() as {
-        data?: {
-          teams: {
-            nodes: TeamNode[]
-            pageInfo: {
-              hasNextPage: boolean
-              endCursor: string | null
-            }
-          }
-        }
-        errors?: Array<{ message: string }>
-      };
+    const result = await paginateLinearConnection<TeamNode>({
+      apiToken,
+      query,
+      extract: (data) =>
+        (data as { teams: LinearConnection<TeamNode> }).teams,
+    });
 
-      if (result.errors) {
-        throw new Error(`GraphQL errors: ${result.errors.map(e => e.message).join(', ')}`);
-      }
-
-      if (!result.data) {
-        throw new Error('No data returned from Linear API');
-      }
-
-      allTeams.push(...result.data.teams.nodes);
-      hasNextPage = result.data.teams.pageInfo.hasNextPage;
-      endCursor = result.data.teams.pageInfo.endCursor;
+    if (!result.success) {
+      throw new Error(result.error);
     }
 
     return NextResponse.json({
       success: true,
-      teams: allTeams.map(team => ({
+      teams: result.nodes.map(team => ({
         id: team.id,
         name: team.name,
         key: team.key,

--- a/src/lib/linear.ts
+++ b/src/lib/linear.ts
@@ -1,4 +1,96 @@
 /**
+ * Shape of a Relay-style connection returned by the Linear GraphQL API.
+ */
+export type LinearConnection<T> = {
+  nodes: T[];
+  pageInfo: {
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+};
+
+/**
+ * Fetches every page of a Linear GraphQL connection by following `endCursor`
+ * until `hasNextPage` is false.
+ *
+ * The supplied `query` must declare `$after: String` and pass it to the
+ * connection being paginated. `extract` navigates from the `data` object to
+ * the connection (which allows nested shapes like `data.project.projectUpdates`).
+ * `maxPages` bounds the loop so a misbehaving API cannot hang the request.
+ */
+export async function paginateLinearConnection<T>(args: {
+  apiToken: string;
+  query: string;
+  variables?: Record<string, unknown>;
+  extract: (data: Record<string, unknown>) => LinearConnection<T>;
+  maxPages?: number;
+}): Promise<{ success: true; nodes: T[] } | { success: false; error: string }> {
+  const { apiToken, query, variables = {}, extract, maxPages = 100 } = args;
+
+  const allNodes: T[] = [];
+  let endCursor: string | null = null;
+  let hasNextPage = true;
+  let pages = 0;
+
+  while (hasNextPage) {
+    if (pages++ >= maxPages) {
+      return {
+        success: false,
+        error: `Pagination exceeded safety limit (${maxPages} pages)`,
+      };
+    }
+
+    const response = await fetch('https://api.linear.app/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: apiToken.trim(),
+      },
+      body: JSON.stringify({
+        query,
+        variables: { ...variables, after: endCursor },
+      }),
+    });
+
+    if (!response.ok) {
+      let errorDetails = '';
+      try {
+        errorDetails = ` - ${await response.text()}`;
+      } catch {
+        // Ignore text parsing errors
+      }
+      return {
+        success: false,
+        error: `Linear API error: ${response.status} ${response.statusText}${errorDetails}`,
+      };
+    }
+
+    const result = (await response.json()) as {
+      data?: Record<string, unknown>;
+      errors?: Array<{ message: string }>;
+    };
+
+    if (result.errors) {
+      return {
+        success: false,
+        error: `GraphQL errors: ${result.errors.map((e) => e.message).join(', ')}`,
+      };
+    }
+
+    if (!result.data) {
+      return { success: false, error: 'No data returned from Linear API' };
+    }
+
+    const connection = extract(result.data);
+    allNodes.push(...connection.nodes);
+    hasNextPage = connection.pageInfo.hasNextPage;
+    endCursor = connection.pageInfo.endCursor;
+  }
+
+  return { success: true, nodes: allNodes };
+}
+
+/**
  * Linear issue type returned from the API
  */
 export type LinearIssue = {


### PR DESCRIPTION
## Summary
- Extracts the cursor-pagination loop added in #9 into a reusable `paginateLinearConnection` helper in `src/lib/linear.ts`, with a `maxPages` safety guard (default 100) so a misbehaving cursor can't hang a request.
- Refactors `projects` and `teams` routes to use the helper (dedupes ~60 lines of near-identical code).
- Applies the helper to two other endpoints that were silently capped at Linear's 50-default: `issues` (was explicitly `first: 50`) and `project-updates` (had no `first:` argument at all).
- Removes the `console.log` that leaked the first 20 characters of the API token from the `projects` and `teams` routes.

## Behaviour changes
- `issues` and `project-updates` now return every matching result instead of the first 50. Bounded by `maxPages * 250 = 25 000` per request.
- `projects`/`teams` are functionally identical to main (same pagination shape, just via the helper).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx next lint` has no new warnings on touched files
- [ ] Smoke test the Source dropdown on a workspace with >250 projects
- [ ] Smoke test the project updates modal on a project with >50 updates
- [ ] Smoke test the issues list on a project with >50 issues