### PR TITLE
feat: add visibility controls to hide internal comments and activity from public views

### DIFF
--- a/src/app/api/public-view/[slug]/issue/[issueId]/route.ts
+++ b/src/app/api/public-view/[slug]/issue/[issueId]/route.ts
@@ -121,6 +121,52 @@ export async function GET(
     // Decrypt the token
     const decryptedToken = decryptToken(profileData.linear_api_token);
 
+    // Build GraphQL query based on view visibility settings
+    const showComments = viewData.show_comments ?? false;
+    const showActivity = viewData.show_activity ?? false;
+
+    const commentsFragment = showComments ? `
+          comments {
+            nodes {
+              id
+              body
+              createdAt
+              updatedAt
+              user {
+                id
+                name
+                avatarUrl
+              }
+            }
+          }` : '';
+
+    const historyFragment = showActivity ? `
+          history {
+            nodes {
+              id
+              createdAt
+              fromState {
+                name
+                color
+              }
+              toState {
+                name
+                color
+              }
+              fromAssignee {
+                name
+              }
+              toAssignee {
+                name
+              }
+              fromPriority
+              toPriority
+              actor {
+                name
+              }
+            }
+          }` : '';
+
     // Fetch issue details from Linear using GraphQL
     const query = `
       query IssueDetail($issueId: String!) {
@@ -150,45 +196,7 @@ export async function GET(
             }
           }
           createdAt
-          updatedAt
-          comments {
-            nodes {
-              id
-              body
-              createdAt
-              updatedAt
-              user {
-                id
-                name
-                avatarUrl
-              }
-            }
-          }
-          history {
-            nodes {
-              id
-              createdAt
-              fromState {
-                name
-                color
-              }
-              toState {
-                name
-                color
-              }
-              fromAssignee {
-                name
-              }
-              toAssignee {
-                name
-              }
-              fromPriority
-              toPriority
-              actor {
-                name
-              }
-            }
-          }
+          updatedAt${commentsFragment}${historyFragment}
         }
       }
     `;
@@ -240,7 +248,7 @@ export async function GET(
           };
           createdAt: string;
           updatedAt: string;
-          comments: {
+          comments?: {
             nodes: Array<{
               id: string;
               body: string;
@@ -253,7 +261,7 @@ export async function GET(
               };
             }>;
           };
-          history: {
+          history?: {
             nodes: Array<{
               id: string;
               createdAt: string;
@@ -312,8 +320,8 @@ export async function GET(
       labels: issue.labels.nodes,
       createdAt: issue.createdAt,
       updatedAt: issue.updatedAt,
-      comments: issue.comments.nodes,
-      history: issue.history.nodes.map(h => ({
+      comments: issue.comments?.nodes || [],
+      history: (issue.history?.nodes || []).map(h => ({
         id: h.id,
         createdAt: h.createdAt,
         fromState: h.fromState,

--- a/src/app/api/public-view/[slug]/route.ts
+++ b/src/app/api/public-view/[slug]/route.ts
@@ -94,6 +94,8 @@ export async function GET(
         show_priorities: viewData.show_priorities,
         show_descriptions: viewData.show_descriptions,
         allow_issue_creation: viewData.allow_issue_creation,
+        show_comments: viewData.show_comments ?? false,
+        show_activity: viewData.show_activity ?? false,
         created_at: viewData.created_at
       },
       issues: issuesResult.issues
@@ -215,6 +217,8 @@ export async function POST(
         show_descriptions: viewData.show_descriptions,
         password_protected: viewData.password_protected,
         allow_issue_creation: viewData.allow_issue_creation,
+        show_comments: viewData.show_comments ?? false,
+        show_activity: viewData.show_activity ?? false,
         created_at: viewData.created_at
       },
       issues: issuesResult.issues

--- a/src/app/profile/branding/page.tsx
+++ b/src/app/profile/branding/page.tsx
@@ -516,7 +516,7 @@ export default function BrandingPage() {
                   rows={2}
                 />
               </div>
-              <div className="flex items-center space-x-2">
+              <div className="flex items-center gap-2">
                 <Checkbox
                   checked={branding.show_powered_by ?? true}
                   onChange={() =>

--- a/src/app/roadmaps/page.tsx
+++ b/src/app/roadmaps/page.tsx
@@ -396,7 +396,7 @@ export default function RoadmapsPage() {
                         <p className="text-sm text-muted-foreground">No projects found</p>
                       ) : (
                         projects.map((project) => (
-                          <div key={project.id} className="flex items-center space-x-2">
+                          <div key={project.id} className="flex items-center gap-2">
                             <Checkbox
                               checked={selectedProjects.includes(project.id)}
                               onChange={() => toggleProjectSelection(project.id)}
@@ -429,7 +429,7 @@ export default function RoadmapsPage() {
                   </div>
 
                   <div className="space-y-3 pt-2">
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center gap-2">
                       <Checkbox
                         checked={allowVoting}
                         onChange={() => setAllowVoting(!allowVoting)}
@@ -438,7 +438,7 @@ export default function RoadmapsPage() {
                         Allow visitors to upvote items
                       </label>
                     </div>
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center gap-2">
                       <Checkbox
                         checked={allowComments}
                         onChange={() => setAllowComments(!allowComments)}
@@ -447,7 +447,7 @@ export default function RoadmapsPage() {
                         Allow visitors to comment on items
                       </label>
                     </div>
-                    <div className="flex items-center space-x-2">
+                    <div className="flex items-center gap-2">
                       <Checkbox
                         checked={passwordProtected}
                         onChange={() => setPasswordProtected(!passwordProtected)}

--- a/src/app/view/[slug]/page.tsx
+++ b/src/app/view/[slug]/page.tsx
@@ -543,6 +543,7 @@ export default function PublicViewPage({ params }: PublicViewPageProps) {
           viewSlug={slug}
           showComments={view?.show_comments}
           showActivity={view?.show_activity}
+          showDescriptions={view?.show_descriptions}
         />
       )}
 

--- a/src/app/view/[slug]/page.tsx
+++ b/src/app/view/[slug]/page.tsx
@@ -541,6 +541,8 @@ export default function PublicViewPage({ params }: PublicViewPageProps) {
           onClose={handleCloseIssueDetail}
           issueId={selectedIssueId}
           viewSlug={slug}
+          showComments={view?.show_comments}
+          showActivity={view?.show_activity}
         />
       )}
 

--- a/src/app/views/page.tsx
+++ b/src/app/views/page.tsx
@@ -70,6 +70,8 @@ export default function PublicViewsPage() {
   const [editingView, setEditingView] = useState<PublicView | null>(null);
   const [showEditView, setShowEditView] = useState(false);
   const [allowIssueCreation, setAllowIssueCreation] = useState(false);
+  const [showComments, setShowComments] = useState(false);
+  const [showActivity, setShowActivity] = useState(false);
 
   const loadUserData = useCallback(async () => {
     if (!user) return;
@@ -237,6 +239,8 @@ export default function PublicViewsPage() {
         show_labels: true,
         show_priorities: true,
         show_descriptions: true,
+        show_comments: showComments,
+        show_activity: showActivity,
         allowed_statuses: [],
         password_protected: passwordProtected,
         password_hash: passwordHash,
@@ -323,6 +327,8 @@ export default function PublicViewsPage() {
     setPasswordProtected(false);
     setPassword("");
     setAllowIssueCreation(false);
+    setShowComments(false);
+    setShowActivity(false);
     setShowCreateView(false);
     setEditingView(null);
     setShowEditView(false);
@@ -337,6 +343,8 @@ export default function PublicViewsPage() {
     setPasswordProtected(view.password_protected || false);
     setPassword("");
     setAllowIssueCreation(view.allow_issue_creation || false);
+    setShowComments(view.show_comments || false);
+    setShowActivity(view.show_activity || false);
 
     // Set source type and selection based on existing view
     if (view.project_id) {
@@ -418,6 +426,8 @@ export default function PublicViewsPage() {
           password_protected: passwordProtected,
           password_hash: passwordHash,
           allow_issue_creation: allowIssueCreation,
+          show_comments: showComments,
+          show_activity: showActivity,
           ...sourceData,
         })
         .eq("id", editingView.id);
@@ -760,6 +770,44 @@ export default function PublicViewsPage() {
                       </p>
                     </div>
                   </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showComments}
+                        onChange={() => setShowComments(!showComments)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="show-comments"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show comments on issue detail
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display Linear comments (internal discussions) when viewing issue details
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showActivity}
+                        onChange={() => setShowActivity(!showActivity)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="show-activity"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show activity history on issue detail
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display status changes, assignee changes, and other activity when viewing issue details
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -1008,6 +1056,44 @@ export default function PublicViewsPage() {
                       </Label>
                       <p className="text-xs text-muted-foreground mt-1">
                         Enable a &quot;Create issue&quot; button in the public board view
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showComments}
+                        onChange={() => setShowComments(!showComments)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="edit-show-comments"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show comments on issue detail
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display Linear comments (internal discussions) when viewing issue details
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showActivity}
+                        onChange={() => setShowActivity(!showActivity)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="edit-show-activity"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show activity history on issue detail
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display status changes, assignee changes, and other activity when viewing issue details
                       </p>
                     </div>
                   </div>

--- a/src/components/issue-detail-modal.tsx
+++ b/src/components/issue-detail-modal.tsx
@@ -11,6 +11,8 @@ interface IssueDetailModalProps {
   onClose: () => void
   issueId: string
   viewSlug: string
+  showComments?: boolean
+  showActivity?: boolean
 }
 
 const getPriorityIcon = (priority: number) => {
@@ -95,11 +97,11 @@ const formatDate = (dateString: string) => {
   return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
-export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDetailModalProps) {
+export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug, showComments = false, showActivity = false }: IssueDetailModalProps) {
   const [issue, setIssue] = useState<IssueDetail | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<'activity' | 'comments'>('activity')
+  const [activeTab, setActiveTab] = useState<'activity' | 'comments'>(showActivity ? 'activity' : 'comments')
 
   useEffect(() => {
     if (isOpen && issueId) {
@@ -369,9 +371,11 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDe
                 </div>
               )}
 
-              {/* Activity/Comments Tabs */}
+              {/* Activity/Comments Tabs - only shown when enabled in view settings */}
+              {(showComments || showActivity) && (
               <div className="border-t border-border pt-6">
                 <div className="flex items-center gap-4 mb-6">
+                  {showActivity && (
                   <button
                     onClick={() => setActiveTab('activity')}
                     className={`text-sm font-medium pb-2 border-b-2 transition-colors ${
@@ -382,6 +386,8 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDe
                   >
                     Activity
                   </button>
+                  )}
+                  {showComments && (
                   <button
                     onClick={() => setActiveTab('comments')}
                     className={`text-sm font-medium pb-2 border-b-2 transition-colors ${
@@ -392,10 +398,11 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDe
                   >
                     Comments ({issue.comments.length})
                   </button>
+                  )}
                 </div>
 
                 {/* Activity Tab */}
-                {activeTab === 'activity' && (
+                {showActivity && activeTab === 'activity' && (
                   <div className="space-y-4">
                     {activityItems.length === 0 && (
                       <p className="text-sm text-muted-foreground text-center py-8">No activity yet</p>
@@ -477,7 +484,7 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDe
                 )}
 
                 {/* Comments Tab */}
-                {activeTab === 'comments' && (
+                {showComments && activeTab === 'comments' && (
                   <div className="space-y-4">
                     {issue.comments.length === 0 && (
                       <p className="text-sm text-muted-foreground text-center py-8">No comments yet</p>
@@ -501,6 +508,7 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug }: IssueDe
                   </div>
                 )}
               </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/issue-detail-modal.tsx
+++ b/src/components/issue-detail-modal.tsx
@@ -13,6 +13,7 @@ interface IssueDetailModalProps {
   viewSlug: string
   showComments?: boolean
   showActivity?: boolean
+  showDescriptions?: boolean
 }
 
 const getPriorityIcon = (priority: number) => {
@@ -97,7 +98,7 @@ const formatDate = (dateString: string) => {
   return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
-export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug, showComments = false, showActivity = false }: IssueDetailModalProps) {
+export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug, showComments = false, showActivity = false, showDescriptions = true }: IssueDetailModalProps) {
   const [issue, setIssue] = useState<IssueDetail | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -282,7 +283,7 @@ export function IssueDetailModal({ isOpen, onClose, issueId, viewSlug, showComme
               </div>
 
               {/* Description */}
-              {issue.description && (
+              {showDescriptions && issue.description && (
                 <div className="mb-8">
                   <h3 className="text-sm font-medium text-foreground mb-3">Description</h3>
                   <div className="prose prose-sm max-w-none text-foreground/90 markdown-content">

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -60,6 +60,8 @@ export type PublicView = {
   show_labels: boolean
   show_priorities: boolean
   show_descriptions: boolean
+  show_comments: boolean
+  show_activity: boolean
   allowed_statuses: string[]
   password_protected: boolean
   password_hash?: string

--- a/supabase/migrations/011_add_visibility_controls.sql
+++ b/supabase/migrations/011_add_visibility_controls.sql
@@ -1,0 +1,8 @@
+-- Add visibility controls for hiding internal data from public views
+-- These columns control what information is visible to public visitors
+
+-- show_comments: whether to show Linear comments (internal discussions) on issue detail
+ALTER TABLE public_views ADD COLUMN IF NOT EXISTS show_comments BOOLEAN DEFAULT false;
+
+-- show_activity: whether to show issue activity history (status changes, assignee changes, etc.)
+ALTER TABLE public_views ADD COLUMN IF NOT EXISTS show_activity BOOLEAN DEFAULT false;


### PR DESCRIPTION
## Summary

- Add `show_comments` and `show_activity` boolean columns to `public_views` (both default to `false`)
- When disabled, the API skips fetching comments/history from Linear entirely (not just hiding in UI)
- Issue detail modal conditionally renders Activity/Comments tabs based on view settings
- Respect existing `show_descriptions` setting in issue detail modal (previously only applied to issue list)
- New migration: `011_add_visibility_controls.sql`

## Test plan

- Create a public view with comments and activity disabled (default) - verify issue detail shows no Activity/Comments tabs and no description
- Enable show_comments - verify comments tab appears with Linear comments
- Enable show_activity - verify activity tab appears with status/assignee/priority changes
- Enable show_descriptions - verify description appears in issue detail
- Verify existing views still work (columns default to false)