### PR TITLE
Add toggle to hide project updates from public views

### DIFF
--- a/src/app/api/public-view/[slug]/route.ts
+++ b/src/app/api/public-view/[slug]/route.ts
@@ -93,6 +93,7 @@ export async function GET(
         show_labels: viewData.show_labels,
         show_priorities: viewData.show_priorities,
         show_descriptions: viewData.show_descriptions,
+        show_project_updates: viewData.show_project_updates ?? true,
         allow_issue_creation: viewData.allow_issue_creation,
         created_at: viewData.created_at
       },
@@ -213,6 +214,7 @@ export async function POST(
         show_labels: viewData.show_labels,
         show_priorities: viewData.show_priorities,
         show_descriptions: viewData.show_descriptions,
+        show_project_updates: viewData.show_project_updates ?? true,
         password_protected: viewData.password_protected,
         allow_issue_creation: viewData.allow_issue_creation,
         created_at: viewData.created_at

--- a/src/app/view/[slug]/page.tsx
+++ b/src/app/view/[slug]/page.tsx
@@ -338,7 +338,7 @@ export default function PublicViewPage({ params }: PublicViewPageProps) {
               </div>
             )}
 
-            {view.project_id && (
+            {view.project_id && view.show_project_updates !== false && (
               <button
                 onClick={() => setShowProjectUpdates(true)}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"

--- a/src/app/views/page.tsx
+++ b/src/app/views/page.tsx
@@ -70,6 +70,7 @@ export default function PublicViewsPage() {
   const [editingView, setEditingView] = useState<PublicView | null>(null);
   const [showEditView, setShowEditView] = useState(false);
   const [allowIssueCreation, setAllowIssueCreation] = useState(false);
+  const [showProjectUpdates, setShowProjectUpdates] = useState(true);
 
   const loadUserData = useCallback(async () => {
     if (!user) return;
@@ -242,6 +243,7 @@ export default function PublicViewsPage() {
         password_hash: passwordHash,
         is_active: true,
         allow_issue_creation: allowIssueCreation,
+        show_project_updates: showProjectUpdates,
         ...sourceData,
       });
 
@@ -323,6 +325,7 @@ export default function PublicViewsPage() {
     setPasswordProtected(false);
     setPassword("");
     setAllowIssueCreation(false);
+    setShowProjectUpdates(true);
     setShowCreateView(false);
     setEditingView(null);
     setShowEditView(false);
@@ -337,6 +340,7 @@ export default function PublicViewsPage() {
     setPasswordProtected(view.password_protected || false);
     setPassword("");
     setAllowIssueCreation(view.allow_issue_creation || false);
+    setShowProjectUpdates(view.show_project_updates !== false);
 
     // Set source type and selection based on existing view
     if (view.project_id) {
@@ -418,6 +422,7 @@ export default function PublicViewsPage() {
           password_protected: passwordProtected,
           password_hash: passwordHash,
           allow_issue_creation: allowIssueCreation,
+          show_project_updates: showProjectUpdates,
           ...sourceData,
         })
         .eq("id", editingView.id);
@@ -760,6 +765,25 @@ export default function PublicViewsPage() {
                       </p>
                     </div>
                   </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showProjectUpdates}
+                        onChange={() => setShowProjectUpdates(!showProjectUpdates)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="show-project-updates"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show project updates
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display the project updates button on the public board view
+                      </p>
+                    </div>
+                  </div>
                 </div>
               </div>
 
@@ -1008,6 +1032,25 @@ export default function PublicViewsPage() {
                       </Label>
                       <p className="text-xs text-muted-foreground mt-1">
                         Enable a &quot;Create issue&quot; button in the public board view
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <Checkbox
+                        checked={showProjectUpdates}
+                        onChange={() => setShowProjectUpdates(!showProjectUpdates)}
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Label
+                        htmlFor="edit-show-project-updates"
+                        className="text-sm font-medium cursor-pointer"
+                      >
+                        Show project updates
+                      </Label>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Display the project updates button on the public board view
                       </p>
                     </div>
                   </div>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -60,6 +60,7 @@ export type PublicView = {
   show_labels: boolean
   show_priorities: boolean
   show_descriptions: boolean
+  show_project_updates: boolean
   allowed_statuses: string[]
   password_protected: boolean
   password_hash?: string

--- a/supabase/migrations/011_add_show_project_updates.sql
+++ b/supabase/migrations/011_add_show_project_updates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public_views ADD COLUMN IF NOT EXISTS show_project_updates BOOLEAN DEFAULT true;


### PR DESCRIPTION
Adds show_project_updates boolean column (default true) to public_views. Toggle in create/edit forms. Updates button hidden on public view when disabled.