### PR TITLE
feat: White label - set document title and favicon from branding

### DIFF
--- a/src/app/form/[slug]/page.tsx
+++ b/src/app/form/[slug]/page.tsx
@@ -122,9 +122,9 @@ export default function PublicFormPage() {
   // Apply branding when it loads
   useEffect(() => {
     if (branding) {
-      applyBrandingToPage(branding)
+      applyBrandingToPage(branding, formConfig?.form_title)
     }
-  }, [branding])
+  }, [branding, formConfig])
 
   const onFormSubmit = async (values: FormData) => {
     if (!formConfig) return

--- a/src/app/roadmap/[slug]/page.tsx
+++ b/src/app/roadmap/[slug]/page.tsx
@@ -204,9 +204,9 @@ export default function RoadmapPage({ params }: RoadmapPageProps) {
   // Apply branding when it loads
   useEffect(() => {
     if (branding) {
-      applyBrandingToPage(branding)
+      applyBrandingToPage(branding, roadmap?.title)
     }
-  }, [branding])
+  }, [branding, roadmap])
 
   if (loading) {
     return (

--- a/src/app/view/[slug]/page.tsx
+++ b/src/app/view/[slug]/page.tsx
@@ -488,7 +488,7 @@ export default function PublicViewPage({ params }: PublicViewPageProps) {
       </div>
 
       {/* Custom Footer */}
-      {!error && (
+      {!error && (branding?.footer_text || !view?.allow_issue_creation || branding?.show_powered_by !== false) && (
         <footer className="px-4 sm:px-6 pb-6 mt-auto">
           <div className="text-center py-8 border-t border-border/30">
             {branding?.footer_text ? (

--- a/src/app/view/[slug]/page.tsx
+++ b/src/app/view/[slug]/page.tsx
@@ -197,9 +197,9 @@ export default function PublicViewPage({ params }: PublicViewPageProps) {
   // Apply branding when it loads
   useEffect(() => {
     if (branding) {
-      applyBrandingToPage(branding)
+      applyBrandingToPage(branding, view?.view_title)
     }
-  }, [branding])
+  }, [branding, view])
 
   const hasActiveFilters = () => {
     return filters.search ||

--- a/src/hooks/use-branding.ts
+++ b/src/hooks/use-branding.ts
@@ -40,7 +40,7 @@ export function useBrandingSettings(userId: string | null) {
 }
 
 // Helper function to apply branding colours to CSS variables
-export function applyBrandingToPage(branding: BrandingSettings | null) {
+export function applyBrandingToPage(branding: BrandingSettings | null, pageTitle?: string) {
   if (!branding) return;
 
   const root = document.documentElement;
@@ -110,6 +110,12 @@ export function applyBrandingToPage(branding: BrandingSettings | null) {
     }
 
     styleElement.textContent = branding.custom_css;
+  }
+
+  // Apply document title from branding
+  if (branding.brand_name || pageTitle) {
+    const parts = [pageTitle, branding.brand_name].filter(Boolean);
+    document.title = parts.join(' - ');
   }
 
   // Apply favicon


### PR DESCRIPTION
Sets document title from branding tagline/brand name and favicon from branding settings on public pages. Also hides empty footer when no content to display.